### PR TITLE
ignore DS_Store

### DIFF
--- a/app/Banco_de_Medicamentos/.gitignore
+++ b/app/Banco_de_Medicamentos/.gitignore
@@ -2,6 +2,13 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+# OS-specific files
+*.DS_Store
+.DS_Store
+*.Trashes
+.Trashes
+Thumbs.db
+
 ## User settings
 xcuserdata/
 


### PR DESCRIPTION
Aparentemente la plantilla gitignore no tenia para ignorar estos archivos
https://en.wikipedia.org/wiki/.DS_Store
https://es.linkedin.com/learning/trucos-para-desarrollo-web/elimina-esos-molestos-archivos-ds-store